### PR TITLE
Add Delete Customers Example Script

### DIFF
--- a/delete-customers/index.js
+++ b/delete-customers/index.js
@@ -1,10 +1,10 @@
-require("dotenv").config();
+require('dotenv').config();
 
-const csv = require("csvtojson");
-const { findCustomer, deleteCustomer } = require("../util/api");
+const csv = require('csvtojson');
+const { findCustomer, deleteCustomer } = require('../util/api');
 
 //Keep note of rate limits: https://developer.gladly.com/rest/#section/Default-Rate-Limit
-const queue = require("queue");
+const queue = require('queue');
 const q = new queue({
   concurrency: 5,
 });
@@ -17,7 +17,7 @@ csv()
       const row = rows[rowIdx];
 
       q.push((cb) => {
-        findCustomer(row.email, "email") //can also be looked up with phone number, e.g. `findCustomer(row.phone, "phoneNumber")`
+        findCustomer(row.email, 'email') //can also be looked up with phone number, e.g. `findCustomer(row.phone, "phoneNumber")`
           .then((matches) => {
             matches = matches.data;
 

--- a/delete-customers/index.js
+++ b/delete-customers/index.js
@@ -1,0 +1,70 @@
+require("dotenv").config();
+
+const csv = require("csvtojson");
+const { findCustomer, deleteCustomer } = require("../util/api");
+
+//Keep note of rate limits: https://developer.gladly.com/rest/#section/Default-Rate-Limit
+const queue = require("queue");
+const q = new queue({
+  concurrency: 5,
+});
+
+//Load CSV file
+csv()
+  .fromFile(`${__dirname}/sample-new-customers.csv`)
+  .then((rows) => {
+    for (const rowIdx in rows) {
+      const row = rows[rowIdx];
+
+      q.push((cb) => {
+        findCustomer(row.email, "email") //can also be looked up with phone number, e.g. `findCustomer(row.phone, "phoneNumber")`
+          .then((matches) => {
+            matches = matches.data;
+
+            if (matches.length) {
+              console.log(
+                `SUCCESS - ROW ${rowIdx}: Found a match for customer with email ${row.email}. Attempting to delete profile`
+              );
+              //There should only ever be one profile that has this email in Gladly, and we only need their id to delete
+              const customerId = matches[0].id;
+
+              deleteCustomer(customerId)
+                .then(() => {
+                  console.log( `SUCCESS - ROW ${rowIdx}: Deleted customer profile with id ${customerId}` );
+
+                  cb();
+                })
+                .catch((e) => {
+                  console.log(`ERROR - ROW ${rowIdx}: Could not delete customer profile with id ${customerId} due to ${JSON.stringify(
+                      e.response.data
+                    )} and HTTP status code ${e.response.status}`
+                  );
+
+                  cb();
+                });
+            } else {
+              console.log(`ERROR - ROW ${rowIdx}: Could not find customer with email ${row.email}. This profile does not exist in Gladly`);
+
+              cb();
+            }
+          })
+          .catch((e) => {
+            console.log(`ERROR - ROW ${rowIdx}: Could not find customer with email ${row.email} due to ${JSON.stringify(
+              e.response.data
+            )} and HTTP status code ${e.response.status}`
+            );
+
+            cb();
+          });
+      });
+    }
+
+    console.log(`Starting API calls\n\n`);
+    q.start(() => {
+      console.log(`\n\nFinished processing file`);
+    });
+  })
+  .catch((e) => {
+    //Something went wrong opening the CSV file
+    console.log(`Could not open CSV file to delete customers due to ${JSON.stringify(e)}`);
+  });

--- a/delete-customers/sample-customers-to-delete.csv
+++ b/delete-customers/sample-customers-to-delete.csv
@@ -1,0 +1,5 @@
+﻿name,address,email,phone
+First1 Last1,"Address 1, CA, 12345",person1@person.com,650 123 4567
+First2 Last2,"Address 2, CA, 12345",person2@person.com,650 123 4568
+FIrst3 Last3,"Address 3, CA, 12345",person3@person.com,650 123 4569
+First4 Last4,"Address 4, CA, 12345",person4@person.com,650 123 4569

--- a/util/api.js
+++ b/util/api.js
@@ -20,6 +20,11 @@ module.exports.updateCustomer = function(customerObject) {
   return gladlyApiRequest('PATCH', `/api/v1/customer-profiles/${customerObject.id}`, customerObject);
 }
 
+//https://developer.gladly.com/rest/#operation/deleteCustomer
+module.exports.deleteCustomer = function (customerId) {
+  return gladlyApiRequest("DELETE", `/api/v1/customer-profiles/${customerId}`);
+};
+
 //https://developer.gladly.com/rest/#operation/redactContent
 module.exports.redactConversationItem = function(id) {
   return gladlyApiRequest('POST', `/api/v1/conversation-items/${id}/redact`);

--- a/util/api.js
+++ b/util/api.js
@@ -22,7 +22,7 @@ module.exports.updateCustomer = function(customerObject) {
 
 //https://developer.gladly.com/rest/#operation/deleteCustomer
 module.exports.deleteCustomer = function (customerId) {
-  return gladlyApiRequest("DELETE", `/api/v1/customer-profiles/${customerId}`);
+  return gladlyApiRequest('DELETE', `/api/v1/customer-profiles/${customerId}`);
 };
 
 //https://developer.gladly.com/rest/#operation/redactContent


### PR DESCRIPTION
# Delete Customer Example Script
This PR adds an example script to delete customers via the Gladly REST API

## Changes
- Added a deleteCustomer method to utils/api
- Provided an example script for deleting customers in a batch from a CSV, as well as a sample customer data CSV

## Notes
- I followed all the instructions in the written guide and the endpoint documentation such that this *should* work, but I don't have a means to test it yet, so I can't claim 100% bug absence for sure