### PR TITLE
Create and Update Topic example scripts and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,3 +446,71 @@ Starting API calls
 1,How to: Say Hello,,update,_sKRhTfySU2VGCHjmWU8vw
 2,How to: Say Goodbye,,add,hUx7Cdt-RReT_RsnXG_-kQ
 ```
+
+## Create Topics
+
+### What this script does
+
+This script creates new Topics in Gladly utilizing a CSV file in `create-topics/sample-new-topics.csv`.
+
+The script transforms each row in the CSV file to a Topic object, pulling the necessary attributes, then uses the [Gladly Add Topic API](https://developer.gladly.com/rest/#operation/addTopic) to create the Topic on Gladly.
+
+When a Topic is successfully created, the script will log the success using `console.log`
+
+When a Topic fails to be created, the script will log the error using `console.log`, along with the HTTP status code received.
+
+#### CSV to Gladly API data mapping logic
+
+The script will loop through each row in the CSV file and import a Topic using the following logic:
+- `id`: this column is mapped to the Topic's id in Gladly (optional)
+- `name`: this column is mapped to the Topic name on Gladly (required)
+- `disabled`: this column is mapped to whether the Topic is active or archived on Gladly. (optional -- defaults to `false`/active on Gladly)
+- `parentId`: this column is mapped to the id of a parent Topic, if creating a nested topic (optional)
+
+A sample payload can be found below:
+```
+{"id":"id4","name":"Wrong Size","disabled":false,"parentId":"id2"}
+```
+
+### How to use script
+
+Make sure you are in the root directory of this repository on Terminal, then run this command:
+
+`node create-topics`
+
+### Sample console logs from script
+
+```
+SUCCESS - ROW 0: Created Topic with ID id1 and payload {"id":"id1","name":"Returns"}
+SUCCESS - ROW 3: Created Topic with ID id4 and payload {"id":"id4","name":"Wrong Size","parentId":"id1"}
+SUCCESS - ROW 1: Created Topic with ID id2 and payload {"id":"id2","name":"Exchanges"}
+SUCCESS - ROW 2: Created Topic with ID id3 and payload {"id":"id3","name":"Loyalty Program (ARCHIVED)","disabled":true}
+```
+
+## Update Customers
+
+We recommend utilizing this script after running the `create-topics` script.
+
+### What this script does
+
+This script updates an organization's Topics in Gladly utilizing a CSV file in `update-topics/sample-update-topics.csv`.
+
+Topics are updated by making a call to the corresponding Topic id, using the [Gladly Update Topic API](https://developer.gladly.com/rest/#operation/updateTopic).
+
+When a Topic is successfully updated, the script will log the success using `console.log`
+
+When a Topic fails to be update, the script will log the error using `console.log`, along with the HTTP status code received.
+
+
+### How to use script
+
+Make sure you are in the root directory of this repository on Terminal, then run this command:
+
+`node update-topics`
+
+### Sample console logs from script
+
+```
+SUCCESS - ROW 0: Updated Topic with ID id3 and payload {"id":"id3","name":"Loyalty Program","disabled":false}
+SUCCESS - ROW 1: Updated Topic with ID id4 and payload {"id":"id4","name":"Wrong Size","parentId":"id2"}
+```

--- a/create-topics/index.js
+++ b/create-topics/index.js
@@ -1,0 +1,54 @@
+require('dotenv').config();
+
+const csv = require('csvtojson');
+const { createTopic } = require('../util/api');
+
+//Keep note of rate limits: https://developer.gladly.com/rest/#section/Default-Rate-Limit
+const queue = require('queue');
+let q = new queue({
+  concurrency: 2
+});
+
+//Load CSV file
+csv().fromFile(`${__dirname}/sample-new-topics.csv`)
+.then((rows) => {
+  for (let rowIdx in rows) {
+    let row = rows[rowIdx];
+
+    if (row.disabled) {
+      row.disabled = row.disabled === "true" ? true : false; //The `disabled` field expects a boolean type, if present
+    }
+    // Note that the sample data used here illustrates that several fields are optional, only `name` is required
+    // An id will be created by Gladly, if a Topic is submitted without one. Here, we specify our id's for the sake of our update-topics script.
+    const topicObject = {};
+    for (const field in row) {
+      if (row[field]) {
+        topicObject[field] = row[field];
+      }
+    }
+  
+    q.push((cb) => {
+      createTopic(topicObject)
+      .then(() => {
+        console.log(`SUCCESS - ROW ${rowIdx}: Created Topic with ID ${topicObject.id} and payload ${JSON.stringify(topicObject)}`);
+
+        cb();
+      })
+      .catch((e) => {
+        console.log(`ERROR - ROW ${rowIdx}: Could not create Topic with payload ${JSON.stringify(topicObject)} due to ${JSON.stringify(e.response.data)} and HTTP status code ${e.response.status}`);
+
+        cb();
+      })
+    });
+  }
+  
+  console.log(`\n\nStarting API calls\n\n`);
+  q.start(() => {
+    console.log(`\n\nFinished processing file`)
+  });
+}
+)
+.catch((e) => {
+  //Something went wrong opening the CSV file
+  console.log(`Could not open CSV file to create new Topics due to ${JSON.stringify(e)}`);
+});

--- a/create-topics/sample-new-topics.csv
+++ b/create-topics/sample-new-topics.csv
@@ -1,0 +1,5 @@
+id,name,disabled,parentId
+id1,Returns,false,
+id2,Exchanges,,
+id3,Loyalty Program (ARCHIVED),true,
+id4,Wrong Size,,id1

--- a/update-topics/index.js
+++ b/update-topics/index.js
@@ -1,0 +1,54 @@
+require('dotenv').config();
+
+const csv = require('csvtojson');
+const { updateTopic } = require('../util/api');
+
+//Keep note of rate limits: https://developer.gladly.com/rest/#section/Default-Rate-Limit
+const queue = require('queue');
+let q = new queue({
+  concurrency: 5
+});
+
+//Load CSV file
+csv().fromFile(`${__dirname}/sample-update-topics.csv`)
+.then((rows) => {
+  for (let rowIdx in rows) {
+    let row = rows[rowIdx];
+
+    if (row.disabled) {
+      row.disabled = row.disabled === "true" ? true : false; //The `disabled` field expects a boolean type, if present
+    }
+  
+    const topicObject = {};
+    for (const field in row) {
+      if (row[field] || typeof row[field] === "boolean") { //We have to check here for setting `disabled` to `false` on update
+        topicObject[field] = row[field];
+      }
+    }
+
+    const topicId = row.id;
+    q.push((cb) => {
+      updateTopic(topicId, topicObject)
+      .then(() => {
+        console.log(`SUCCESS - ROW ${rowIdx}: Updated Topic with ID ${topicObject.id} and payload ${JSON.stringify(topicObject)}`);
+
+        cb();
+      })
+      .catch((e) => {
+        console.log(`ERROR - ROW ${rowIdx}: Could not update Topic with payload ${JSON.stringify(topicObject)} due to ${JSON.stringify(e.response.data)} and HTTP status code ${e.response.status}`);
+
+        cb();
+      })
+    });
+  }
+  
+  console.log(`\n\nStarting API calls\n\n`);
+  q.start(() => {
+    console.log(`\n\nFinished processing file`)
+  });
+}
+)
+.catch((e) => {
+  //Something went wrong opening the CSV file
+  console.log(`Could not open CSV file to create new Topics due to ${JSON.stringify(e)}`);
+});

--- a/update-topics/sample-update-topics.csv
+++ b/update-topics/sample-update-topics.csv
@@ -1,0 +1,3 @@
+id,name,disabled,parentId
+id3,Loyalty Program,false,
+id4,Wrong Size,,id2

--- a/util/api.js
+++ b/util/api.js
@@ -136,3 +136,13 @@ module.exports.deleteAnswerContent = function(answerId, language, type) {
 module.exports.listAudiences = function() {
   return gladlyApiRequest('GET', `/api/v1/audiences`);
 }
+
+//https://developer.gladly.com/rest/#operation/addTopic
+module.exports.createTopic = function(payload) {
+  return gladlyApiRequest('POST', `/api/v1/topics`, payload);
+}
+
+//https://developer.gladly.com/rest/#operation/updateTopic
+module.exports.updateTopic = function(topicId, payload) {
+  return gladlyApiRequest('PATCH', `/api/v1/topics/${topicId}`, payload);
+}


### PR DESCRIPTION
## Summary
- Create Topics example script
- Update Topics example script
- Demo CSV data for examples
- Script documentation in README
- API methods

## Testing
Set up working .env credentials (API Token and user email address) and call scripts from root directory:
`node create-topics`
`node update-topics`
